### PR TITLE
Feat: POST /v1/memo-room 메모 룸 생성 API 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest -i --config ./test/jest-e2e.json",
+    "test:e2e": "jest -i --verbose --config ./test/jest-e2e.json",
     "test:unit": "jest --testPathPattern=.*\\.unit\\.spec.\\ts$",
     "db:up": "docker-compose -f docker-compose.development-db.yml up -d",
     "db:down": "docker-compose -f docker-compose.$npm_config_env-db.yml down"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,9 +7,10 @@ import { JwtAuthModule } from './common/modules/jwt-auth/jwt-auth.module';
 import { AppConfigService } from './common/config/app/config.service';
 import { ApiSuccessLoggerMiddleware } from './common/middlewares/api-success-logger.middleware';
 import { ApiErrorLoggerMiddleware } from './common/middlewares/api-error-logger.middleware';
+import { MemoRoomModule } from './app/memo-room/memo-room.module';
 
 @Module({
-  imports: [AppConfigModule, DatabaseModule, JwtAuthModule, UserModule, AuthModule],
+  imports: [AppConfigModule, DatabaseModule, JwtAuthModule, UserModule, AuthModule, MemoRoomModule],
   controllers: [],
   providers: [],
 })

--- a/src/app/memo-room/__test__/memo-room.entity.spec.ts
+++ b/src/app/memo-room/__test__/memo-room.entity.spec.ts
@@ -1,0 +1,44 @@
+import { Test } from '@nestjs/testing';
+import { MemoRoom } from '../memo-room.entity';
+import { MemoRoomCatrgory } from '../type/memo-room-category';
+import { DatabaseModule } from '../../../common/config/database/database.module';
+import { DataSource } from 'typeorm';
+
+describe('MemoRoom Entity Test', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [DatabaseModule],
+    }).compile();
+
+    dataSource = module.get(DataSource);
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  test('create', async () => {
+    // given
+    const memoRoom = new MemoRoom();
+    memoRoom.name = 'test';
+    memoRoom.category = MemoRoomCatrgory.DEFAULT;
+
+    const em = dataSource.createEntityManager();
+
+    // when
+    await em.save(memoRoom);
+
+    // then
+    expect(memoRoom).toMatchObject({
+      id: expect.any(Number),
+      name: 'test',
+      category: MemoRoomCatrgory.DEFAULT,
+      isPinned: false,
+      image: '',
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    });
+  });
+});

--- a/src/app/memo-room/__test__/memo-room.entity.spec.ts
+++ b/src/app/memo-room/__test__/memo-room.entity.spec.ts
@@ -3,6 +3,7 @@ import { MemoRoom } from '../memo-room.entity';
 import { MemoRoomCatrgory } from '../type/memo-room-category';
 import { DatabaseModule } from '../../../common/config/database/database.module';
 import { DataSource } from 'typeorm';
+import { getMemoRoom } from './memo-room.fixture';
 
 describe('MemoRoom Entity Test', () => {
   let dataSource: DataSource;
@@ -39,6 +40,23 @@ describe('MemoRoom Entity Test', () => {
       image: '',
       createdAt: expect.any(Date),
       updatedAt: expect.any(Date),
+    });
+  });
+
+  test('read', async () => {
+    // given
+    const memoRoom = getMemoRoom();
+    const em = dataSource.createEntityManager();
+
+    await em.save(memoRoom);
+
+    // when
+    const savedMemoRoom = await em.findOne(MemoRoom, { where: { id: memoRoom.id } });
+
+    // then
+
+    expect(savedMemoRoom).toMatchObject({
+      ...memoRoom,
     });
   });
 });

--- a/src/app/memo-room/__test__/memo-room.fixture.ts
+++ b/src/app/memo-room/__test__/memo-room.fixture.ts
@@ -1,10 +1,12 @@
 import { faker } from '@faker-js/faker';
 import { MemoRoomCatrgory } from '../type/memo-room-category';
 import { MemoRoom } from '../memo-room.entity';
+import { getUser } from '../../user/__test__/user.fixture';
 
 export const getMemoRoom = (data: Partial<MemoRoom> = {}) => {
   const memoRoom = new MemoRoom();
   memoRoom.id = data.id || faker.datatype.number({ min: 1 });
+  memoRoom.user = data.user || Promise.resolve(getUser());
   memoRoom.category = data.category || MemoRoomCatrgory.DEFAULT;
   memoRoom.name = data.name || faker.word.noun();
   memoRoom.isPinned = data.isPinned || false;

--- a/src/app/memo-room/__test__/memo-room.fixture.ts
+++ b/src/app/memo-room/__test__/memo-room.fixture.ts
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker';
+import { MemoRoomCatrgory } from '../type/memo-room-category';
+import { MemoRoom } from '../memo-room.entity';
+
+export const getMemoRoom = (data: Partial<MemoRoom> = {}) => {
+  const memoRoom = new MemoRoom();
+  memoRoom.id = data.id || faker.datatype.number({ min: 1 });
+  memoRoom.category = data.category || MemoRoomCatrgory.DEFAULT;
+  memoRoom.name = data.name || faker.word.noun();
+  memoRoom.isPinned = data.isPinned || false;
+  memoRoom.image = data.image || '';
+  memoRoom.createdAt = data.createdAt || new Date();
+  memoRoom.updatedAt = data.updatedAt || new Date();
+  return memoRoom;
+};

--- a/src/app/memo-room/dto/create-memo-room-request.dto.ts
+++ b/src/app/memo-room/dto/create-memo-room-request.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsString, Length } from 'class-validator';
+import { MemoRoom } from '../memo-room.entity';
+import { MemoRoomCatrgory } from '../type/memo-room-category';
+
+export class CreateMemoRoomRequest {
+  @IsString()
+  @Length(2, 20)
+  @ApiProperty({ example: '장보기목록' })
+  name: string;
+
+  @IsIn(MemoRoomCatrgory.values().map((v) => v.name))
+  @ApiProperty({ example: 'DEFAULT' })
+  category: string;
+
+  toEntity() {
+    const memoRoom = new MemoRoom();
+    memoRoom.name = this.name;
+    memoRoom.category = MemoRoomCatrgory.valueOf(this.category);
+    return memoRoom;
+  }
+}

--- a/src/app/memo-room/dto/memo-room-id.dto.ts
+++ b/src/app/memo-room/dto/memo-room-id.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { MemoRoom } from '../memo-room.entity';
+
+export class MemoRoomId {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  static of(memoRoom: MemoRoom) {
+    const memoRoomId = new MemoRoomId();
+    memoRoomId.id = memoRoom.id;
+    return memoRoomId;
+  }
+}

--- a/src/app/memo-room/memo-room.controller.ts
+++ b/src/app/memo-room/memo-room.controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { MemoRoomService } from './memo-room.service';
+
+@Controller('/memo-rooms')
+@ApiTags('MemoRoom')
+export class MemoRoomController {
+  constructor(private readonly memoRoomService: MemoRoomService) {}
+}

--- a/src/app/memo-room/memo-room.controller.ts
+++ b/src/app/memo-room/memo-room.controller.ts
@@ -1,9 +1,28 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, HttpStatus, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { User } from '../user/user.entity';
+import { ApiErrorResponse } from '../../common/decorators/api-error-response.decorator';
+import { ApiSuccessResponse } from '../../common/decorators/api-success-response.decorator';
+import { Auth } from '../../common/decorators//auth.decorator';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { MemoRoomService } from './memo-room.service';
+import { CreateMemoRoomRequest } from './dto/create-memo-room-request.dto';
+import { BadParameterException } from '../../common/exceptions/bad-parameter.exception';
+import { ResponseEntity } from '../../common/response/response-entity';
+import { MemoRoomId } from './dto/memo-room-id.dto';
 
 @Controller('/memo-rooms')
 @ApiTags('MemoRoom')
 export class MemoRoomController {
   constructor(private readonly memoRoomService: MemoRoomService) {}
+
+  @Post('/')
+  @Auth()
+  @ApiSuccessResponse(HttpStatus.CREATED, MemoRoomId)
+  @ApiErrorResponse(BadParameterException)
+  async create(@CurrentUser() user: User, @Body() body: CreateMemoRoomRequest) {
+    const memoRoom = await this.memoRoomService.create(user, body.toEntity());
+
+    return ResponseEntity.OK_WITH_DATA(MemoRoomId.of(memoRoom));
+  }
 }

--- a/src/app/memo-room/memo-room.entity.ts
+++ b/src/app/memo-room/memo-room.entity.ts
@@ -1,10 +1,15 @@
 import { BaseEntity } from '../../common/base-entity';
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { MemoRoomCatrgory } from './type/memo-room-category';
 import { MemoRoomCategoryTransformer } from './type/memo-room-category.transformer';
+import { User } from '../user/user.entity';
 
 @Entity({ name: 'memo_room' })
 export class MemoRoom extends BaseEntity {
+  @ManyToOne(() => User, { lazy: true, nullable: false })
+  @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
+  user: Promise<User>;
+
   @Column({ type: 'varchar', length: 20 })
   name: string;
 
@@ -16,4 +21,8 @@ export class MemoRoom extends BaseEntity {
 
   @Column({ type: 'varchar', default: '' })
   image: string;
+
+  setUser(user: User) {
+    this.user = Promise.resolve(user);
+  }
 }

--- a/src/app/memo-room/memo-room.entity.ts
+++ b/src/app/memo-room/memo-room.entity.ts
@@ -1,0 +1,19 @@
+import { BaseEntity } from '../../common/base-entity';
+import { Column, Entity } from 'typeorm';
+import { MemoRoomCatrgory } from './type/memo-room-category';
+import { MemoRoomCategoryTransformer } from './type/memo-room-category.transformer';
+
+@Entity({ name: 'memo_room' })
+export class MemoRoom extends BaseEntity {
+  @Column({ type: 'varchar', length: 20 })
+  name: string;
+
+  @Column({ default: false })
+  isPinned: boolean;
+
+  @Column({ type: 'varchar', default: 'DEFAULT', transformer: new MemoRoomCategoryTransformer() })
+  category: MemoRoomCatrgory;
+
+  @Column({ type: 'varchar', default: '' })
+  image: string;
+}

--- a/src/app/memo-room/memo-room.module.ts
+++ b/src/app/memo-room/memo-room.module.ts
@@ -1,4 +1,10 @@
 import { Module } from '@nestjs/common';
+import { MemoRoomController } from './memo-room.controller';
+import { MemoRoomService } from './memo-room.service';
+import { MemoRoomRepository } from './memo-room.repository';
 
-@Module({})
+@Module({
+  controllers: [MemoRoomController],
+  providers: [MemoRoomRepository, MemoRoomService],
+})
 export class MemoRoomModule {}

--- a/src/app/memo-room/memo-room.module.ts
+++ b/src/app/memo-room/memo-room.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class MemoRoomModule {}

--- a/src/app/memo-room/memo-room.repository.ts
+++ b/src/app/memo-room/memo-room.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { MemoRoom } from './memo-room.entity';
+import { DataSource, Repository } from 'typeorm';
+
+@Injectable()
+export class MemoRoomRepository extends Repository<MemoRoom> {
+  constructor(private readonly dataSource: DataSource) {
+    super(MemoRoom, dataSource.createEntityManager(), dataSource.createQueryRunner());
+  }
+}

--- a/src/app/memo-room/memo-room.service.ts
+++ b/src/app/memo-room/memo-room.service.ts
@@ -1,7 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { MemoRoom } from '../memo-room/memo-room.entity';
+import { User } from '../user/user.entity';
 import { MemoRoomRepository } from './memo-room.repository';
 
 @Injectable()
 export class MemoRoomService {
   constructor(private readonly memoRoomRepository: MemoRoomRepository) {}
+
+  async create(user: User, memoRoom: MemoRoom) {
+    memoRoom.setUser(user);
+
+    await this.memoRoomRepository.save(memoRoom);
+
+    return memoRoom;
+  }
 }

--- a/src/app/memo-room/memo-room.service.ts
+++ b/src/app/memo-room/memo-room.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { MemoRoomRepository } from './memo-room.repository';
+
+@Injectable()
+export class MemoRoomService {
+  constructor(private readonly memoRoomRepository: MemoRoomRepository) {}
+}

--- a/src/app/memo-room/type/memo-room-category.transformer.ts
+++ b/src/app/memo-room/type/memo-room-category.transformer.ts
@@ -1,0 +1,14 @@
+import { MemoRoomCatrgory } from './memo-room-category';
+import { ValueTransformer } from 'typeorm';
+
+export class MemoRoomCategoryTransformer implements ValueTransformer {
+  to(entityValue: MemoRoomCatrgory): string {
+    if (!(entityValue instanceof MemoRoomCatrgory)) return null;
+
+    return entityValue.name;
+  }
+
+  from(databaseValue: string): MemoRoomCatrgory {
+    return MemoRoomCatrgory.find(databaseValue);
+  }
+}

--- a/src/app/memo-room/type/memo-room-category.ts
+++ b/src/app/memo-room/type/memo-room-category.ts
@@ -1,0 +1,26 @@
+import { Enum, EnumType } from 'ts-jenum';
+
+@Enum('_name')
+export class MemoRoomCatrgory extends EnumType<MemoRoomCatrgory>() {
+  static readonly DEFAULT = new MemoRoomCatrgory('DEFAULT');
+
+  static readonly WISHLIST = new MemoRoomCatrgory('WISHLIST');
+
+  static readonly CALENDER = new MemoRoomCatrgory('CALENDER');
+
+  static readonly BUDGET = new MemoRoomCatrgory('BUDGET');
+
+  static readonly STUDY = new MemoRoomCatrgory('STUDY');
+
+  constructor(private readonly _name: string) {
+    super();
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  equals(v: MemoRoomCatrgory): boolean {
+    return this.name === v.name;
+  }
+}

--- a/src/common/config/database/postgresql/config.serivce.unit.spec.ts
+++ b/src/common/config/database/postgresql/config.serivce.unit.spec.ts
@@ -1,73 +1,64 @@
 import { Test } from '@nestjs/testing';
-import { MysqlConfigModule } from './config.module';
-import { MysqlConfigService } from './config.service';
+import { PostgreSQLConfigModule } from './config.module';
+import { PostgreSQLConfigService } from './config.service';
 
-describe('MySQL Config Module Test', () => {
-  let mysqlConfigService: MysqlConfigService;
+describe('Postgres Config Module Test', () => {
+  let postgreConfigService: PostgreSQLConfigService;
 
   beforeEach(async () => {
     const app = await Test.createTestingModule({
-      imports: [MysqlConfigModule],
+      imports: [PostgreSQLConfigModule],
     }).compile();
 
-    mysqlConfigService = app.get(MysqlConfigService);
+    postgreConfigService = app.get(PostgreSQLConfigService);
   });
 
-  describe('MySQL Config Service Test', () => {
-    test('MYSQL_DATABASE를 반환하는가', async () => {
+  describe('Postgre Config Service Test', () => {
+    test('POSTGRES_DB를  반환하는가', async () => {
       // given
 
       // when
-      const dbname = mysqlConfigService.dbName;
+      const dbname = postgreConfigService.dbName;
 
       // then
-      expect(dbname).toEqual(process.env.MYSQL_DATABASE);
+      expect(dbname).toEqual(process.env.POSTGRES_DB);
     });
 
-    test('MYSQL_PORT를 반환하는가', async () => {
+    test('POSTGRES_PORT를 반환하는가', async () => {
       // given
 
       // when
-      const port = mysqlConfigService.port;
+      const port = postgreConfigService.port;
 
       // then
-      expect(port).toEqual(parseInt(process.env.MYSQL_PORT, 10));
+      expect(port).toEqual(parseInt(process.env.POSTGRES_PORT, 10));
     });
-    test('MYSQL_HOSTNAME 반환하는가', async () => {
+    test('POSTGRES_HOSTNAME 반환하는가', async () => {
       // given
 
       // when
-      const hostName = mysqlConfigService.hostName;
+      const hostName = postgreConfigService.hostName;
 
       // then
-      expect(hostName).toEqual(process.env.MYSQL_HOSTNAME);
+      expect(hostName).toEqual(process.env.POSTGRES_HOSTNAME);
     });
-    test('MYSQL_USERNAME를 반환하는가', async () => {
+    test('POSTGRES_USER를 반환하는가', async () => {
       // given
 
       // when
-      const userName = mysqlConfigService.userName;
+      const userName = postgreConfigService.userName;
 
       // then
-      expect(userName).toEqual(process.env.MYSQL_USERNAME);
+      expect(userName).toEqual(process.env.POSTGRES_USER);
     });
-    test('MYSQL_PASSWORD를 반환하는가', async () => {
+    test('POSTGRES_PASSWORD를 반환하는가', async () => {
       // given
 
       // when
-      const password = mysqlConfigService.passwrod;
+      const password = postgreConfigService.password;
 
       // then
-      expect(password).toEqual(process.env.MYSQL_PASSWORD);
-    });
-    test('MYSQL_CONNECTION_TIMEOUT를 반환하는가', async () => {
-      // given
-
-      // when
-      const maxConnectionTimeout = mysqlConfigService.maxConnectionTimeout;
-
-      // then
-      expect(maxConnectionTimeout).toEqual(parseInt(process.env.MYSQL_CONNECTION_TIMEOUT, 10));
+      expect(password).toEqual(process.env.POSTGRES_PASSWORD);
     });
   });
 });

--- a/src/common/exceptions/bad-parameter.exception.ts
+++ b/src/common/exceptions/bad-parameter.exception.ts
@@ -3,7 +3,7 @@ import { ResponseStatus } from '../response/response-status';
 import { ErrorInfo } from './error-info';
 
 export class BadParameterException extends BadRequestException {
-  constructor(message: string) {
+  constructor(message = '유효하지 않은 요청 값입니다') {
     super(new ErrorInfo(ResponseStatus.BAD_PARAMETERS, message));
   }
 }

--- a/src/setSwagger.ts
+++ b/src/setSwagger.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { MemoRoomModule } from './app/memo-room/memo-room.module';
 import { AuthModule } from './app/auth/auth.module';
 import { UserModule } from './app/user/user.module';
 import { AppConfigService } from './common/config/app/config.service';
@@ -16,7 +17,7 @@ export const setSwagger = (app: INestApplication) => {
     .build();
 
   const document = SwaggerModule.createDocument(app, config, {
-    include: [AuthModule, UserModule],
+    include: [AuthModule, UserModule, MemoRoomModule],
     extraModels: [ResponseEntity],
   });
 

--- a/src/setSwagger.ts
+++ b/src/setSwagger.ts
@@ -12,7 +12,7 @@ export const setSwagger = (app: INestApplication) => {
   const config = new DocumentBuilder()
     .setTitle('Wanted-Pre-Onboarding REST API')
     .setVersion('1.0.0')
-    .addServer(`http://localhost:${appConfigService.port}`)
+    .addServer(`http://localhost:${appConfigService.port}/v1`)
     .addBearerAuth({ type: 'http', scheme: 'bearer', bearerFormat: 'JWT' }, 'bearerAuth')
     .build();
 

--- a/test/memo-room.e2e-spec.ts
+++ b/test/memo-room.e2e-spec.ts
@@ -1,0 +1,96 @@
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AccessToken } from './utils/access-token';
+import { DataSource } from 'typeorm';
+import { MemoRoomModule } from '../src/app/memo-room/memo-room.module';
+import { getUser } from '../src/app/user/__test__/user.fixture';
+import { AppConfigModule } from '../src/common/config/app/config.module';
+import { DatabaseModule } from '../src/common/config/database/database.module';
+import { JwtAuthModule } from '../src/common/modules/jwt-auth/jwt-auth.module';
+import { setNestApp } from '../src/setNsetApp';
+import { ErrorInfo } from '../src/common/exceptions/error-info';
+import { InvalidTokenException } from '../src/common/exceptions/invalid-token.exception';
+import { MemoRoom } from '../src/app/memo-room/memo-room.entity';
+import { MemoRoomCatrgory } from '../src/app/memo-room/type/memo-room-category';
+
+describe('MomoRoom E2E Test', () => {
+  const route = '/v1/memo-rooms';
+  let app: INestApplication;
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppConfigModule, DatabaseModule, JwtAuthModule, MemoRoomModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    dataSource = module.get(DataSource);
+
+    setNestApp(app);
+
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('Craete', () => {
+    const url = `${route}`;
+
+    test('메모룸 생성 후 201응답과 함께 생성된 메모룸 아이디를 응답하는가', async () => {
+      // given
+      const user = getUser();
+
+      const em = dataSource.createEntityManager();
+
+      await em.save(user);
+
+      const accessToken = AccessToken.of(user);
+
+      // when
+      const res = await request(app.getHttpServer())
+        .post(url)
+        .set({ Authorization: accessToken.bearerForm })
+        .send({ name: 'test', category: 'DEFAULT' });
+
+      // then
+      expect(res.status).toEqual(HttpStatus.CREATED);
+      expect(res.body).toMatchObject({
+        status: 'OK',
+        message: '',
+        data: {
+          id: expect.any(Number),
+        },
+      });
+
+      const memoRoom = await em.findOne(MemoRoom, { where: { user: { id: user.id } } });
+      expect(memoRoom).toMatchObject({
+        id: res.body.data.id,
+        name: 'test',
+        category: MemoRoomCatrgory.DEFAULT,
+      });
+    });
+
+    test('토큰이 없는 경우 401을 응답하는가', async () => {
+      // given
+      const user = getUser();
+
+      const em = dataSource.createEntityManager();
+
+      await em.save(user);
+
+      // when
+      const res = await request(app.getHttpServer()).post(url).send({ name: 'test', category: 'DEFAULT' });
+
+      // then
+      expect(res.status).toEqual(HttpStatus.UNAUTHORIZED);
+      const errorInfo = new InvalidTokenException().getResponse() as ErrorInfo<any>;
+      expect(res.body).toMatchObject({
+        status: errorInfo.errorCode,
+        message: errorInfo.message,
+      });
+    });
+  });
+});

--- a/test/utils/access-token.ts
+++ b/test/utils/access-token.ts
@@ -1,0 +1,29 @@
+import jwt from 'jsonwebtoken';
+import moment from 'moment';
+import { TokenPayload } from '../../src/common/modules/token/type/token-payload';
+import { User } from '../../src/app/user/user.entity';
+import { TokenType } from '../../src/common/modules/token/type/token-type';
+
+export class AccessToken {
+  private _token: string;
+
+  private constructor(user: User) {
+    const payload: TokenPayload = {
+      sub: user.id,
+      exp: moment().add(1, 'd').unix(),
+      iat: moment().unix(),
+      type: TokenType.ACCESS.code,
+    };
+
+    this._token = jwt.sign(payload, process.env.JWT_SECRET);
+  }
+
+  static of(user: User) {
+    const token = new AccessToken(user);
+    return token;
+  }
+
+  get bearerForm() {
+    return `bearer ${this._token}`;
+  }
+}


### PR DESCRIPTION
# 개발사항

- 메모룸 엔티티 추가
- POST /v1/memo-rooms 메모룸 생성 API 추가
- 메모룸 생성 E2E 테스트 코드 추가

--- 

## 메모룸 엔티티 추가

메모룸 엔티티를 아래와 같이 추가했어요.
유저와 다대일 연관관계설정하고 lazy로딩되도록 했습니다.
우선 ERD클라우드에 있는 것을 보고 만들었어요. 추가적으로 지난번에 이야기 했던 이미지를 서버에서 전달해주는 것 관련해서 궁금한게 있습니다.

우선 이미지 컬럼을 추가해서 S3에 이미지가 추가되면 이미지 링크를 image컬럼에 저장하고 클라이언트에 전달해준다고 생각하고 만들었어요. 이런식으로 생각하신게 맞을지 궁금해서요! 아니면 서버에서 상수로 가지고 있다가 넘겨주는 걸까요?

한편으로는 메모룸 이미지가 사용자 누구에게나 고정적이라고 생각해서 굳이 서버에서 내려줄 이유가 있나? 라는 생각이 조금 들어서요! 커스텀이 가능하거나 변경이 잦은게 아니라면 오히려 클라이언트 쪽에서 고정적으로 하는게 어떨까 하는 생각이 조금 들었습니다.

https://github.com/memochat/memochat-server/blob/0c01d6ba0b2f32b51483740513a70d56da2d69f3/src/app/memo-room/memo-room.entity.ts#L7-L28

--- 

## POST /v1/memo-rooms 메모룸 생성 API 추가

메모룸에 이름과 카테고리를 받아서 유저의 메모룸을 생성할 수 있도록 했어요!

성공시 201과 생성된 메모룸 id를 반환하도록 했습니다.

---

## 메모룸 생성 E2E 테스트 코드 추가

  MomoRoom E2E Test
    Craete
      ✓ 메모룸 생성 후 201응답과 함께 생성된 메모룸 아이디를 응답하는가 (581 ms)
      ✓ 토큰이 없는 경우 401을 응답하는가 (294 ms)