### PR TITLE
feat: :sparkles: GET & PATCH /password 비밀번호 확인 및 변경 API 구현

### DIFF
--- a/src/app/auth/auth.controller.ts
+++ b/src/app/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, HttpStatus, Param, Post } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ApiErrorResponse } from '../../common/decorators/api-error-response.decorator';
 import { ApiSuccessResponse } from '../../common/decorators/api-success-response.decorator';
 import { InvalidTokenException } from '../../common/exceptions/invalid-token.exception';
@@ -23,6 +23,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('/signup')
+  @ApiOperation({ summary: '회원가입 API', description: '이메일 인증을 거친 후 회원가입 합니다.' })
   @ApiSuccessResponse(HttpStatus.CREATED)
   @ApiErrorResponse(AlreadyExistEmailException, VerficationNotFoundException, EmailNotVerifiedException)
   async signup(@Body() signupRequest: SignupRequestDto) {
@@ -32,6 +33,7 @@ export class AuthController {
   }
 
   @Post('/signin')
+  @ApiOperation({ summary: '로그인 API', description: '로그인 후 토큰을 발급해줍니다.' })
   @ApiSuccessResponse(HttpStatus.OK, AuthTokenDto)
   @ApiErrorResponse(UserNotFoundException, NotMatchedPasswordException)
   async signin(@Body() signinRequest: SigninRequestDto) {
@@ -41,6 +43,7 @@ export class AuthController {
   }
 
   @Post('/refresh-tokens')
+  @ApiOperation({ summary: 'refreshToken 재발급 API', description: '만료된 AccessToken을 재발급 합니다.' })
   @ApiSuccessResponse(HttpStatus.OK, AuthTokenDto)
   @ApiErrorResponse(InvalidTokenException)
   async refreshAuthToken(@Body() refreshTokensRequest: RefreshTokensRequestDto) {
@@ -50,6 +53,7 @@ export class AuthController {
   }
 
   @Post('/emails')
+  @ApiOperation({ summary: 'email 발송 API', description: '가입하지 않은 회원에 대해 이메일을 발송합니다.' })
   @ApiSuccessResponse(HttpStatus.OK)
   @ApiErrorResponse(AlreadyExistEmailException)
   async sendEmail(@Body() sendEmailRequest: EmailRequestDto) {
@@ -59,6 +63,7 @@ export class AuthController {
   }
 
   @Get('/verifications/:email')
+  @ApiOperation({ summary: 'email 검증 확인 API', description: '이메일 인증이 정상적으로 되었는지 확인합니다.' })
   @ApiSuccessResponse(HttpStatus.OK)
   @ApiErrorResponse(EmailNotVerifiedException)
   async checkVerification(@Param('email') email: string) {
@@ -68,6 +73,7 @@ export class AuthController {
   }
 
   @Post('/verify-email')
+  @ApiOperation({ summary: 'email 검증 API', description: '전송한 code로 이메일을 인증합니다.' })
   @ApiSuccessResponse(HttpStatus.OK)
   @ApiErrorResponse(VerficationNotFoundException)
   async verifyEmail(@Body() verifyEmailRequestDto: VerifyEmailRequestDto) {

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -7,6 +7,7 @@ import { UserNotFoundException } from '../../common/exceptions/user-not-found.ex
 import { NotMatchedPasswordException } from '../../common/exceptions/not-matched-password.exception';
 import { TokenService } from '../../common/modules/token/token.service';
 import { SignupRequestDto } from './dto/signup-request.dto';
+import { SigninRequestDto } from './dto/signin-request.dto';
 import { VerifyEmailRequestDto } from './dto/verify-email-request.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Verification } from './verification.entity';
@@ -53,8 +54,9 @@ export class AuthService {
     return user;
   }
 
-  async signin({ email, password }: { email: string; password: string }) {
-    const user = await this.userRepository.findOneBy({ email });
+  async signin({ email, password }: SigninRequestDto) {
+    const user = await this.userRepository.findOne({ where: { email }, select: ['id', 'email', 'password'] });
+    console.log(user);
 
     if (!user) {
       throw new UserNotFoundException();

--- a/src/app/user/dto/password-request.dto.ts
+++ b/src/app/user/dto/password-request.dto.ts
@@ -1,4 +1,4 @@
 import { PickType } from '@nestjs/swagger';
 import { User } from '../user.entity';
 
-export class PatchNicknameRequestDto extends PickType(User, ['nickname']) {}
+export class PasswordRequestDto extends PickType(User, ['password'] as const) {}

--- a/src/app/user/user.controller.ts
+++ b/src/app/user/user.controller.ts
@@ -1,10 +1,13 @@
 import { Body, Controller, HttpStatus, Get, Patch } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiErrorResponse } from 'src/common/decorators/api-error-response.decorator';
+import { NotMatchedPasswordException } from 'src/common/exceptions/not-matched-password.exception';
 import { ResponseEntity } from 'src/common/response/response-entity';
 import { ApiSuccessResponse } from '../../common/decorators/api-success-response.decorator';
 import { Auth } from '../../common/decorators/auth.decorator';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
-import { PathNicknameRequestDto } from './dto/patch-nickname-request.dto';
+import { PasswordRequestDto } from './dto/password-request.dto';
+import { PatchNicknameRequestDto } from './dto/patch-nickname-request.dto';
 import { User } from './user.entity';
 import { UserService } from './user.service';
 
@@ -16,15 +19,37 @@ export class UserController {
   @Get('/me')
   @Auth()
   @ApiOperation({ summary: '유저 정보 조회 API', description: '로그인 된 유저의 정보를 조회합니다.' })
-  @ApiSuccessResponse(HttpStatus.OK)
-  async gets(@CurrentUser() user: User) {
+  @ApiSuccessResponse(HttpStatus.OK, User)
+  async me(@CurrentUser() user: User) {
     return ResponseEntity.OK_WITH_DATA(user);
   }
 
   @Patch('/nickname')
   @Auth()
+  @ApiOperation({ summary: '유저 닉네임 변경 API', description: '유저의 닉네임을 변경합니다.' })
   @ApiSuccessResponse(HttpStatus.NO_CONTENT)
-  async update(@CurrentUser() user: User, @Body() body: PathNicknameRequestDto) {
-    await this.userService.updateNickname(user, body.nickname);
+  async update(@CurrentUser() user: User, @Body() patchNicknameRequestDto: PatchNicknameRequestDto) {
+    await this.userService.updateNickname(user, patchNicknameRequestDto);
+    return ResponseEntity.OK();
+  }
+
+  @Get('/password')
+  @Auth()
+  @ApiOperation({ summary: '유저 비밀번호 확인 API', description: '입력한 비밀번호와 유저의 현재 비밀번호를 확인합니다.' })
+  @ApiSuccessResponse(HttpStatus.OK)
+  @ApiErrorResponse(NotMatchedPasswordException)
+  async checkPassword(@CurrentUser() user: User, @Body() passwordRequestDto: PasswordRequestDto) {
+    await this.userService.checkPassword(user, passwordRequestDto);
+    return ResponseEntity.OK();
+  }
+
+  @Patch('/password')
+  @Auth()
+  @ApiOperation({ summary: '유저 비밀번호 변경 API', description: '유저의 비밀번호를 변경합니다.' })
+  @ApiSuccessResponse(HttpStatus.NO_CONTENT)
+  @ApiErrorResponse(NotMatchedPasswordException)
+  async changePassword(@CurrentUser() user: User, @Body() passwordRequestDto: PasswordRequestDto) {
+    await this.userService.changePassword(user, passwordRequestDto);
+    return ResponseEntity.OK();
   }
 }

--- a/src/app/user/user.entity.ts
+++ b/src/app/user/user.entity.ts
@@ -14,7 +14,7 @@ export class User extends BaseEntity {
   email: string;
 
   @ApiProperty({ example: 'test123', description: 'password', required: true })
-  @Column()
+  @Column({ select: false })
   @Matches(/^(?=.*[a-zA-Z])((?=.*\d)(?=.*\W)).{8,16}$/, {
     message: '비밀번호는 문자, 숫자, 특수문자가 최소 1개 이상 포함되며 8자리에서 최대 16자리 문자열입니다.',
   })

--- a/src/app/user/user.module.ts
+++ b/src/app/user/user.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { HashService } from '../auth/hash.service';
 import { UserController } from './user.controller';
 import { UserRepository } from './user.repository';
 import { UserService } from './user.service';
 
 @Module({
   controllers: [UserController],
-  providers: [UserService, UserRepository],
+  providers: [HashService, UserService, UserRepository],
   exports: [UserRepository],
 })
 export class UserModule {}

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -1,16 +1,39 @@
 import { Injectable } from '@nestjs/common';
+import { NotMatchedPasswordException } from 'src/common/exceptions/not-matched-password.exception';
+import { HashService } from '../auth/hash.service';
+import { PasswordRequestDto } from './dto/password-request.dto';
+import { PatchNicknameRequestDto } from './dto/patch-nickname-request.dto';
 import { User } from './user.entity';
 import { UserRepository } from './user.repository';
 
 @Injectable()
 export class UserService {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(private readonly hashService: HashService, private readonly userRepository: UserRepository) {}
 
-  async updateNickname(user: User, nickname: string) {
+  async updateNickname(user: User, { nickname }: PatchNicknameRequestDto) {
     user.updateNickname(nickname);
 
     await this.userRepository.save(user);
 
     return user;
+  }
+
+  async checkPassword(user: User, { password }: PasswordRequestDto) {
+    const existedUser = await this.userRepository.findOne({ where: { id: user.id }, select: ['id', 'email', 'password'] });
+
+    const passwordCorrect = await this.hashService.compare(password, existedUser.password);
+    if (!passwordCorrect) {
+      throw new NotMatchedPasswordException();
+    }
+    return true;
+  }
+
+  async changePassword(user: User, { password: newPassword }: PasswordRequestDto) {
+    const existedUser = await this.userRepository.findOne({ where: { id: user.id }, select: ['id', 'email', 'password'] });
+
+    existedUser.password = await this.hashService.hash(newPassword);
+    await this.userRepository.save(existedUser);
+
+    return true;
   }
 }


### PR DESCRIPTION
# 개발사항
### USERS

GET /v1/users/password 비밀번호 확인 API 추가
PATCH /v1/users/password 비밀번호 변경 API 추가
PATCH /v1/users/nickname 닉네임 변경 API 수정

# 수정사항

### Users
user Entity 조회 시 password column { select : false } 로 수정
기본 유저 정보 조회 시 비밀번호 조회 안되도록 변경

추후 비밀번호 필요한 기능 생길 시 따로 select 구문 활용 필요 

### Swagger
Swagger 문서 API 상세 내역 업데이트